### PR TITLE
Refactor Windows Power

### DIFF
--- a/killer/killer_windows.py
+++ b/killer/killer_windows.py
@@ -43,19 +43,15 @@ class KillerWindows(KillerBase):
             self.kill_the_system('AC')
 
     def detect_battery(self):
-        status = self._get_power_status()
+        status = power.get_power_status().battery_flag
+        status = power.BatteryFlags(status)
 
         if self.DEBUG:
             print("Battery:")
-            print(status.BatteryFlag)
+            print(status)
             print()
-        elif ('BatteryFlag', status.BatteryFlag) not in [0, 1, 2, 4, 8, 9, 10, 12]:
-            if ('BatteryFlag', status.BatteryFlag) == 128:
-                # Battery not detected, so this is useless
-                pass
-            else:
-                # Battery is not connected, shut down
-                self.kill_the_system('Battery')
+        elif status == power.BatteryFlags.NONE:
+            self.kill_the_system('Battery')
 
     def detect_tray(self):
         raise NotImplementedError

--- a/killer/killer_windows.py
+++ b/killer/killer_windows.py
@@ -32,7 +32,7 @@ class KillerWindows(KillerBase):
 
     def detect_ac(self):
         status = power.get_power_status().ac_line_status
-        status = power.ACLineStatus.from_ubyte(status)
+        status = power.ACLineStatus(status)
 
         if self.DEBUG:
             print("AC:")

--- a/killer/killer_windows.py
+++ b/killer/killer_windows.py
@@ -1,17 +1,9 @@
-import ctypes
 import subprocess
-from ctypes import wintypes
 
 import wmi
 
-from killer.killer_base import KillerBase
-
-
-class SYSTEM_POWER_STATUS(ctypes.Structure):
-    _fields_ = [
-        ('ACLineStatus', ctypes.c_ubyte),
-        ('BatteryFlag', ctypes.c_ubyte),
-    ]
+from .killer_base import KillerBase
+from .windows import power
 
 
 class KillerWindows(KillerBase):
@@ -39,13 +31,14 @@ class KillerWindows(KillerBase):
                     self.kill_the_system('USB Connected Whitelist')
 
     def detect_ac(self):
-        status = self._get_power_status()
+        status = power.get_power_status().ac_line_status
+        status = power.ACLineStatus.from_ubyte(status)
 
         if self.DEBUG:
             print("AC:")
-            print(status.ACLineStatus)
+            print(status.name)
             print()
-        elif ('ACLineStatus', status.ACLineStatus) != 1:
+        elif status != power.ACLineStatus.ONLINE:
             # If not connected to power, shutdown
             self.kill_the_system('AC')
 
@@ -86,16 +79,3 @@ class KillerWindows(KillerBase):
     def kill_the_system(self, warning: str):
         super().kill_the_system(warning)
         subprocess.Popen(["shutdown.exe", "/s", "/f", "/t", "00"])
-
-    @staticmethod
-    def _get_power_status():
-        SYSTEM_POWER_STATUS_P = ctypes.POINTER(SYSTEM_POWER_STATUS)
-        GetSystemPowerStatus = ctypes.windll.kernel32.GetSystemPowerStatus
-        GetSystemPowerStatus.argtypes = [SYSTEM_POWER_STATUS_P]
-        GetSystemPowerStatus.restype = wintypes.BOOL
-        status = SYSTEM_POWER_STATUS()
-
-        if not GetSystemPowerStatus(ctypes.pointer(status)):
-            raise ctypes.WinError()
-        else:
-            return status

--- a/killer/windows/power.py
+++ b/killer/windows/power.py
@@ -15,7 +15,7 @@
 
 import ctypes
 from ctypes import wintypes
-from enum import Enum, IntFlag
+from enum import Enum, Flag
 
 
 class ACLineStatus(Enum):
@@ -24,7 +24,7 @@ class ACLineStatus(Enum):
     UNKNOWN = 255
 
 
-class BatteryFlags(IntFlag):
+class BatteryFlags(Flag):
     HIGH = 1
     LOW = 2
     CRITICAL = 4

--- a/killer/windows/power.py
+++ b/killer/windows/power.py
@@ -23,9 +23,6 @@ class ACLineStatus(Enum):
     ONLINE = 1
     UNKNOWN = 255
 
-    @classmethod
-    def from_ubyte(cls, ubyte: ctypes.c_ubyte):
-        return cls(ubyte.value)
 
 class BatteryFlags(IntFlag):
     HIGH = 1
@@ -34,10 +31,6 @@ class BatteryFlags(IntFlag):
     CHARGING = 8
     NONE = 128
     UNKNOWN = 255
-
-    @classmethod
-    def from_ubyte(cls, ubyte: ctypes.c_ubyte):
-        return cls(ubyte.value)
 
 
 class SystemPowerStatus(ctypes.Structure):

--- a/killer/windows/power.py
+++ b/killer/windows/power.py
@@ -1,0 +1,73 @@
+# <https://github.com/Lvl4Sword/Killer>
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/agpl.html>.
+
+import ctypes
+from ctypes import wintypes
+from enum import Enum, IntFlag
+
+
+class ACLineStatus(Enum):
+    OFFLINE = 0
+    ONLINE = 1
+    UNKNOWN = 255
+
+    @classmethod
+    def from_ubyte(cls, ubyte: ctypes.c_ubyte):
+        return cls(ubyte.value)
+
+class BatteryFlags(IntFlag):
+    HIGH = 1
+    LOW = 2
+    CRITICAL = 4
+    CHARGING = 8
+    NONE = 128
+    UNKNOWN = 255
+
+    @classmethod
+    def from_ubyte(cls, ubyte: ctypes.c_ubyte):
+        return cls(ubyte.value)
+
+
+class SystemPowerStatus(ctypes.Structure):
+    """Contains information about the power status of the system."""
+    _fields_ = [
+        ('ac_line_status', ctypes.c_ubyte),
+        ('battery_flag', ctypes.c_ubyte),
+        ('battery_life_percent', ctypes.c_ubyte),
+        ('system_status_flag', ctypes.c_ubyte),
+        ('battery_life_time', wintypes.DWORD),
+        ('battery_full_life_time', wintypes.DWORD)
+    ]
+
+def get_power_status() -> SystemPowerStatus:
+    """Retrieves the power status of the system.
+
+    The status indicates whether the system is running on AC or DC power,
+    whether the battery is currently charging, how much battery life remains,
+    and if battery saver is on or off.
+
+    :raises OSError: if the call to GetSystemPowerStatus fails
+    :return: the power status
+    :rtype: SystemPowerStatus
+    """
+    get_system_power_status = ctypes.windll.kernel32.GetSystemPowerStatus
+    get_system_power_status.argtypes = [ctypes.POINTER(SystemPowerStatus)]
+    get_system_power_status.restype = wintypes.BOOL
+    status = SystemPowerStatus()
+
+    if not get_system_power_status(ctypes.pointer(status)):
+        raise ctypes.WinError()
+    else:
+        return status


### PR DESCRIPTION
Moves the windows API stuff for power to a separate module. I've also added enums for the AC and battery.

Needs testing as I don't have a Windows laptop set up. Of particular concern is if it's possible for the battery flag to be greater than 128 (NONE) even when the battery is removed e.g. a flag for HIGH along with NONE doesn't seem like too far of a stretch.