### PR TITLE
Some minor stuff

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ setup(
     name='killer',
     version=__version__,
     author=__author__,
-    # author_email='',
     description='Shuts the system down upon disallowed changes',
     # This is what you see on PyPI page
     long_description=Path('README.md').read_text(),
@@ -20,9 +19,9 @@ setup(
     url='https://github.com/Lvl4Sword/Killer',
     project_urls={
         'Discord Server': 'https://discord.gg/python',
+        'Gitter': 'https://gitter.im/KillerPython',
     },
     license=__license__,
-    # data_files=[('killer', ['killer.conf'])],
     packages=find_packages(),
     include_package_data=True,
     zip_safe=True,
@@ -30,9 +29,12 @@ setup(
     entry_points={'console_scripts': ['killer = killer.killer:main']},
     install_requires=Path('requirements.txt').read_text().split(),
     platforms=['Linux', 'Windows'],
-    keywords='killer monitoring watchdog shutdown '
-             'tamper tampering tamper-evident',
-    classifiers=[  # Used by PyPI to classify the project and make it searchable
+    keywords=[
+        'killer', 'kill', 'watch', 'watchdog', 'monitoring', 'monitor',
+        'tamper', 'tampering', 'tamper-evident', 'shutdown', 'poweroff',
+    ],
+    classifiers=[
+        # Used by PyPI to classify the project and make it browsable
         'Development Status :: 3 - Alpha',
         'Environment :: Console',
         'License :: OSI Approved :: GNU Affero General Public License v3',

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,74 @@
+[tox]
+envlist = py{35,36,37}-{linux,windows}
+skip_missing_interpreters = true
+minversion = 3.4
+requires = setuptools
+
+[testenv]
+description = Run CLI tests under {basepython}
+setenv =
+    PIP_DISABLE_VERSION_CHECK = 1
+passenv = http_proxy https_proxy no_proxy SSL_CERT_FILE TOXENV CI TRAVIS TRAVIS_* APPVEYOR APPVEYOR_* CODECOV_*
+commands =
+    killer --help
+    killer --version
+    killer -d
+
+[testenv:codespell]
+description = "Check spelling of code"
+skip_install = true
+ignore_errors = false
+deps = codespell
+commands = codespell --check-filenames --skip="*.pyc,*.class,*.git,*.vagrant,*.tox,*.egg-info,*.idea,*.vscode,_build,.doctrees,build,dist"
+
+[testenv:flake8]
+description = "Code quality inspection"
+skip_install = true
+ignore_errors = false
+deps = flake8
+commands = flake8 killer setup.py
+
+[flake8]
+max-line-length = 99
+ignore = E203, W503, E401, F401, E226
+
+[testenv:check]
+description = "Run all code quality checks (basically everything except tests)"
+skip_install = true
+ignore_errors = false
+deps =
+    check-manifest
+    codespell
+    flake8
+commands =
+    python setup.py check --strict --metadata
+    check-manifest {toxinidir}
+    {[testenv:codespell]commands}
+    {[testenv:flake8]commands}
+
+[testenv:coverage]
+description = "Run the test suite with coverage checks and reporting"
+skip_install = true
+setenv =
+    {[testenv]setenv}
+    COVERAGE_FILE = .coverage.{envname}
+passenv = TOXENV CODECOV_*
+deps =
+    pytest
+    pytest-cov
+    coverage
+commands =
+    pytest --basetemp={envtmpdir} {posargs}
+
+[pytest]
+minversion = 3.4
+testpaths = tests docs
+norecursedirs = .github .git .tox .vagrant .idea .vscode dist build *.egg .*
+cache_dir = {envtmpdir}.pytest_cache
+addopts =
+    --tb=short
+    --cov=killer
+    --cov=tests
+    --cov-report html
+filterwarnings =
+    ignore::DeprecationWarning


### PR DESCRIPTION
Just some minor quality of life stuff.

#### Added Tox configuration
Can use this for code quality checks ("tox -e check, etc.), running
tests, and configuring tools. When running tests, it runs each test
in a isolated environment created using virtualenv. This makes it
trivial to test all the versions of Python we support, provided they
are currently installed (pyenv is useful for this on Linux).

You can install tox with: `pip3 install --user -U tox`

Right now you can do:
* `tox`
* `tox -e check`
* `tox -e codespell`
* `tox -e flake8`
* `tox -e coverage` (Though this won't do anything useful currently)

#### Setup.py improvements
- Keywords should be a list of string, not a string.
Otherwise they don't appear on the left on PyPI.
- Add Gitter chat room to project_urls that appear on PyPI.
- Added some keywords
- Cleaned up some dead code